### PR TITLE
added extension points in submenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 ## [Unreleased]
+### Added
+- Added before and after ExtensionPoints in Submenu
 
 ## [2.0.5] - 2021-06-17
 ### Fixed

--- a/react/Extension.tsx
+++ b/react/Extension.tsx
@@ -1,0 +1,1 @@
+export default ({ children }) => children

--- a/react/MegaMenu/components/HorizontalMenu.tsx
+++ b/react/MegaMenu/components/HorizontalMenu.tsx
@@ -117,7 +117,7 @@ const HorizontalMenu: FC<InjectedIntlProps> = observer(({ intl }) => {
   )
 
   const loaderBlocks = useMemo(() => {
-    const blocks = []
+    const blocks: JSX.Element[] = []
 
     for (let index = 1; index <= 4; index++) {
       blocks.push(

--- a/react/MegaMenu/components/Submenu.tsx
+++ b/react/MegaMenu/components/Submenu.tsx
@@ -6,7 +6,7 @@ import type { InjectedIntlProps } from 'react-intl'
 import { defineMessages, injectIntl } from 'react-intl'
 import { applyModifiers, useCssHandles } from 'vtex.css-handles'
 import { formatIOMessage } from 'vtex.native-types'
-import { Link } from 'vtex.render-runtime'
+import { ExtensionPoint, Link } from 'vtex.render-runtime'
 import { Collapsible } from 'vtex.styleguide'
 
 import type { MenuItem } from '../../shared'
@@ -200,7 +200,10 @@ const Submenu: FC<ItemProps> = observer((props) => {
             )}
           >
             {orientation === 'horizontal' ? (
-              items
+              <>
+                <ExtensionPoint id="before-menu" /> {items}{' '}
+                <ExtensionPoint id="after-menu" />
+              </>
             ) : (
               <>
                 {items}

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "target": "es2017",
+    "noImplicitAny": false,
     "allowSyntheticDefaultImports": true
   },
   "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"]

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,17 @@
 {
   "mega-menu": {
-    "component": "MegaMenu"
+    "component": "MegaMenu",
+    "allowed": ["before-menu", "after-menu"]
+  },
+  "before-menu": {
+    "component": "Extension",
+    "composition": "children",
+    "allowed": "*"
+  },
+  "after-menu": {
+    "component": "Extension",
+    "composition": "children",
+    "allowed": "*"
   },
   "mega-menu-go-back-btn": {
     "component": "GoBackButton"


### PR DESCRIPTION
**What problem is this solving?**

The possibility of adding banners or any other component in submenu

<!--- What is the motivation and context for this change? -->
Added Before and After extension points in submenu in order to incorporate any other blocks in submenu.
**How should this be manually tested?**
https://megamenu--infinityro.myvtex.com/?__bindingAddress=infinity.ro/ro

` "mega-menu": {
    "blocks": ["after-menu"]
  },
  "after-menu": {
    "children": ["image#howToPromoteMarketplaceService"]
  },
`
**Screenshots or example usage:**
You can find them here: https://megamenu--infinityro.myvtex.com/?__bindingAddress=infinity.ro/ro