### PR TITLE
Update readme version dependencie 0.x to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Import the mega menu app to your dependencies as `manifest.json`, for�
 
 ```json
 "dependencies": {
-	"vtex.mega-menu": "0.x"
+	"vtex.mega-menu": "2.x"
 }
 ```
 


### PR DESCRIPTION
**What problem is this solving?**

It is confusing for those just starting out with VTEX IO that the current version of mega menu is 2.x and the documentation has you include 0.x in the manifest

This causes the error: "Missing block vtex.mega-menu@0.x:mega-menu" 