### PR TITLE
fix remove submenus when same slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+### Fixed
+- Bug that removed submenus when editing a menu item and the slug remains the same
 ## [2.6.0] - 2022-03-11
 
 ### Added

--- a/react/FormComponent.tsx
+++ b/react/FormComponent.tsx
@@ -498,7 +498,11 @@ const FormComponent: FC<FormComponentProps & InjectedIntlProps> = (props) => {
 
       if (menuLevelTwo?.length) {
         menuLevelTwo.forEach((item: MenuItem) => {
-          if (item.slugRelative === slug) return
+          if (item.slugRelative === slug) {
+            menuLevelTwoUpdate.push(item)
+
+            return
+          }
 
           const dataPath = getNewPath(
             item.slug,
@@ -532,7 +536,11 @@ const FormComponent: FC<FormComponentProps & InjectedIntlProps> = (props) => {
           menuLevelThirdUpdate = []
           if (itemSecond.menu?.length) {
             itemSecond.menu.forEach((itemThird: MenuItem) => {
-              if (itemSecond.slugRelative === itemThird.slug) return
+              if (itemSecond.slugRelative === itemThird.slug) {
+                menuLevelThirdUpdate.push(itemThird)
+
+                return
+              }
 
               const dataPath = getNewPath(
                 itemThird.slug,
@@ -594,7 +602,11 @@ const FormComponent: FC<FormComponentProps & InjectedIntlProps> = (props) => {
         menuLevelThirdUpdate = []
         if (itemSecond.menu?.length) {
           itemSecond.menu.forEach((itemThird: MenuItem) => {
-            if (itemSecond.slugRelative === itemThird.slug) return
+            if (itemSecond.slugRelative === itemThird.slug) {
+              menuLevelThirdUpdate.push(itemThird)
+
+              return
+            }
 
             const dataPath = getNewPath(
               itemThird.slug,
@@ -620,9 +632,8 @@ const FormComponent: FC<FormComponentProps & InjectedIntlProps> = (props) => {
             }
 
             menuLevelThirdUpdate.push(updateLevel)
-
-            itemSecond.menu = menuLevelThirdUpdate
           })
+          itemSecond.menu = menuLevelThirdUpdate
         }
       })
 


### PR DESCRIPTION
**What problem is this solving?**

A bug that when saving first or second level items without changing the slug, it removes all submenus.

**How should this be manually tested?**

It can be tested here: https://claudiumegamenu2--iviteb.myvtex.com/

**Screenshots or example usage:**