### PR TITLE
Fix/404 categories mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- Fix 404 error on certain categories in mobile view
+
 ## [2.10.1] - 2025-01-30
 
 ## [2.10.0] - 2024-12-13

--- a/react/MegaMenu/components/Submenu.tsx
+++ b/react/MegaMenu/components/Submenu.tsx
@@ -79,10 +79,10 @@ const Submenu: FC<ItemProps> = observer((props) => {
     )
   }
 
-  const subCategories = (items: MenuItem[]) => {
-    return items
-      .filter((v) => v.display)
-      .map((x) => (
+  const subCategories = (items: MenuItem[]) =>
+    items
+      .filter(v => v.display)
+      .map(x => (
         <div key={x.id} className={classNames(handles.submenuItem, 'mt3')}>
           <Item
             to={x.slug}
@@ -96,7 +96,7 @@ const Submenu: FC<ItemProps> = observer((props) => {
           </Item>
         </div>
       ))
-  }
+
 
   const items = useMemo(
     () => {
@@ -132,10 +132,10 @@ const Submenu: FC<ItemProps> = observer((props) => {
                   collapsibleStates[category.id] ? 'isOpen' : 'isClosed'
                 ),
                 (orientation === 'vertical' || openOnly === 'vertical') &&
-                  'c-on-base bb b--light-gray mv0 ph5',
+                'c-on-base bb b--light-gray mv0 ph5',
                 (orientation === 'vertical' || openOnly === 'vertical') &&
-                  i === 0 &&
-                  'bt',
+                i === 0 &&
+                'bt',
                 collapsibleStates[category.id] && 'bg-near-white'
               )}
             >
@@ -186,14 +186,13 @@ const Submenu: FC<ItemProps> = observer((props) => {
                           [category.id]: e.target.isOpen,
                         })
                       } else {
-                        window.location.assign(`${category.slug}`)
+                        window.location.href = `/${category.slug}`
                         if (closeMenu) closeMenu(false)
                       }
                     }}
                     isOpen={collapsibleStates[category.id]}
-                    caretColor={`${
-                      collapsibleStates[category.id] ? 'base' : 'muted'
-                    }`}
+                    caretColor={`${collapsibleStates[category.id] ? 'base' : 'muted'
+                      }`}
                   >
                     {!!subcategories.length && (
                       <div className={handles.collapsibleContent}>
@@ -227,16 +226,16 @@ const Submenu: FC<ItemProps> = observer((props) => {
               handles.submenuContainerTitle,
               'f4 fw7 c-on-base lh-copy ma0 flex items-center',
               orientation === 'horizontal' &&
-                openOnly === 'horizontal' &&
-                'mb6',
+              openOnly === 'horizontal' &&
+              'mb6',
               (orientation === 'vertical' || openOnly === 'vertical') &&
-                'pv5 ph5'
+              'pv5 ph5'
             )}
           >
             {departmentActive.name}
             {orientation === 'horizontal' &&
-            openOnly === 'horizontal' &&
-            showBtnCat ? (
+              openOnly === 'horizontal' &&
+              showBtnCat ? (
               seeAllLink(departmentActive.slug, 1, 't-small ml7')
             ) : (
               <div />
@@ -246,10 +245,10 @@ const Submenu: FC<ItemProps> = observer((props) => {
           <div
             className={classNames(
               orientation === 'horizontal' &&
-                openOnly === 'horizontal' &&
-                styles.submenuList,
+              openOnly === 'horizontal' &&
+              styles.submenuList,
               (orientation === 'vertical' || openOnly === 'vertical') &&
-                handles.submenuListVertical
+              handles.submenuListVertical
             )}
           >
             {orientation === 'horizontal' && openOnly === 'horizontal' ? (


### PR DESCRIPTION
**What problem is this solving?**

On mobile, navigating between certain categories sometimes caused a 404 error. The issue happens because the URL concatenates the previous category and subcategory paths with the new category.

Example:
Navigate first to Banheiros > Duchas e Chuveiros.
Then go to Climatizador.
The URL incorrectly becomes: https://www.obramax.com.br/banheiros/duchas-e-chuveiros/climatizacao-e-ventilacao/climatizadores-de-ar instead of the correct path. This results in a 404 page.

WS: https://ombrec1585--lojaobramax.myvtex.com/

**How should this be manually tested?**

1. Open the website on a mobile device or use a mobile viewport in the browser.
2. Navigate to one category, then select another category in the menu.
3. Verify that the URL updates correctly and the new category page loads without a 404 error.

**Screenshots or example usage:**

Before: https://jam.dev/c/27bb0666-a0ac-44ef-89b6-78e99ba15bac
After: https://www.awesomescreenshot.com/video/45282811?key=71f19bd0438e1949659b9a920819b6e9 
